### PR TITLE
fix: [#95] Fix file-loader configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,8 @@ module.exports = {
                 use: [{
                   loader: 'file-loader',
                   options: {
-                    emitFile: true
+                    emitFile: true,
+                    esModule: false
                   }
                 }]
               }


### PR DESCRIPTION
The default value for the esModule option had changed from false to true in file-loader v5. We need to use false here.

Closes #95 